### PR TITLE
More inclusive regex, let authentic do the validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const Hoek = require('hoek')
 const Authentic = require('@articulate/authentic')
 
 const extractBearerToken = ({ headers: { authorization = '' } }) => {
-  const [, token] = authorization.match(/^Bearer (\w*)$/) || []
+  const [, token] = authorization.match(/^Bearer (.*)$/) || []
   if (token)
     return token
   else


### PR DESCRIPTION
The existing regex would not match a JWT because of `.`s.  It is not the responsibility of this plugin to verify the JWT, so this PR makes the regex more inclusive and delegates the validation to authentic.