### PR TITLE
Upgrade authentic to 1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/articulate/hapi-authentic#readme",
   "dependencies": {
-    "@articulate/authentic": "^1.0.0",
+    "@articulate/authentic": "^1.1.0",
     "boom": "^7.2.0",
     "hoek": "^5.0.3"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -111,6 +111,37 @@ lab.experiment('hapi-authentic', () => {
     })
   })
 
+  lab.experiment('when authentic rejects w/ forbidden', () => {
+    lab.beforeEach(() => {
+      mockAuthentic = sandbox.stub().rejects(Boom.forbidden())
+    })
+
+    it('returns 403', () => {
+      const server = new Hapi.Server()
+      server.connection()
+
+      return new Promise((resolve) => {
+        server.register(require('../'), err => {
+          expect(err).to.not.exist()
+          server.auth.strategy('bearer', 'authentic', { issWhitelist: ['https://iss'] })
+          server.route(route)
+          const request = {
+            method: 'GET',
+            url: '/test',
+            headers: {
+              authorization: 'Bearer TOKENBOI'
+            },
+          }
+          server.inject(request, res => {
+            expect(res.statusCode).to.equal(403)
+            expect(res.result.message).to.equal('Forbidden')
+            resolve()
+          })
+        })
+      })
+    })
+  })
+
   lab.experiment('when authentic resolves', () => {
     lab.beforeEach(() => {
       mockAuthentic = sandbox.stub().resolves({ sub: 'mock-sub' })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@articulate/authentic@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@articulate/authentic/-/authentic-1.0.0.tgz#0a9ba1a927d31a63201b812921aaba31c4d37d4c"
-  integrity sha512-JGPNA17pgNNXSckNf0VFQzNgj8KQF9XW530iU5mEcbe5jIvoqnn4xUyCjAfsXyhK03upv/k/iV1o2e1oLrrE3A==
+"@articulate/authentic@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@articulate/authentic/-/authentic-1.1.0.tgz#d0ebf2afce3ae4b9be054dc58dafd9ec85a3a519"
+  integrity sha512-EJO4yR1vzLZHVeup/ESd3r5hw6faPfYoywTgTLbl0t/m28nF6aCmXf36sgyLpw1UvK5HYuD99oGLF51fpKq60g==
   dependencies:
     "@articulate/funky" "^1.2.0"
     "@articulate/gimme" "^1.0.0"


### PR DESCRIPTION
Pulling in the new version of `@articulate/authentic` (https://github.com/articulate/authentic/pull/7) that differentiates `401` and `403` errors.